### PR TITLE
Update 700.md

### DIFF
--- a/app/game/pyramid/pt/3/700.md
+++ b/app/game/pyramid/pt/3/700.md
@@ -4,9 +4,9 @@ backdrop: images/3-main-chamber.png
 
 # Uma Pista do Livro
 
-Embora seu guia não tenha sido muito útil até agora, você o abre conforme solicitado e descobre uma nota que diz: "Organize todos os glifos na ordem apropriada pelo ... k-neightbor mais próximo."
+Embora seu guia não tenha sido muito útil até agora, você o abre conforme solicitado e descobre uma nota que diz: "Organize todos os glifos na ordem apropriada pelo ... enésimo vizinho mais próximo."
 
-K o quê? E o que é isso de vizinhos? O guia inclui uma imagem de mais um glifo.
+Ene o quê? E o que é isso de vizinhos? O guia inclui uma imagem de mais um glifo.
 
 <Item id="15" />
 


### PR DESCRIPTION
Fixed missing term (added localization)

The expression _k-th_, largely used in Math, in Portuguese is used with the letter _n_ - thus, an adjustment had to be done here.